### PR TITLE
Cleanup mocked data

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -31,8 +31,6 @@ use sp_version::RuntimeVersion;
 use orml_currencies::BasicCurrencyAdapter;
 use orml_traits::parameter_type_with_key;
 
-use hex_literal;
-
 mod address_conv;
 mod balance_conv;
 mod currency_conv;
@@ -326,11 +324,7 @@ parameter_types! {
     pub const StringLimit: u32 = 50;
     pub const MetadataDepositBase: Balance = 10 * XLM;
     pub const MetadataDepositPerByte: Balance = 1 * XLM;
-    pub const GatewayEscrowAccount: &'static str = "GALXBW3TNM7QGHTSQENJA2YJGGHLO3TP7Y7RLKWPZIY4CUHNJ3TDMFON";
     pub GatewayEscrowKeypair: SecretKey = SecretKey::from_encoding("SACLCZW75A7QASXCEPSD4ZZII7THVHDUGCOKUBOINZLSVA3VKTGLOV33").unwrap();
-    pub GatewayMockedDestination: AccountId = hex_literal::hex!("d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d").into();
-    pub GatewayMockedStellarAsset: stellar::Asset = stellar::Asset::AssetTypeNative;
-    pub GatewayEscrowSecretKey: SecretKey = SecretKey::from_encoding("SACLCZW75A7QASXCEPSD4ZZII7THVHDUGCOKUBOINZLSVA3VKTGLOV33").unwrap();
 }
 
 // ---------------------- Stellar Bridge Pallet Configurations ----------------------
@@ -343,11 +337,7 @@ impl pallet_stellar_bridge::Config for Runtime {
     type Call = Call;
     type Event = Event;
     type Currency = Currencies;
-    type GatewayEscrowAccount = GatewayEscrowAccount;
     type GatewayEscrowKeypair = GatewayEscrowKeypair;
-    type GatewayMockedDestination = GatewayMockedDestination;
-    type GatewayMockedStellarAsset = GatewayMockedStellarAsset;
-    type GatewayEscrowSecretKey = GatewayEscrowSecretKey;
 }
 
 pub type SignedPayload = generic::SignedPayload<Call, SignedExtra>;


### PR DESCRIPTION
- Clean up mocked values
- We were passing 3 different objects to represent the Escrow account, unify them in a single one. Just pass the secret key to the pallet,  and then derive the public key when needed.